### PR TITLE
chore: jx-go-loops to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -7,6 +7,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.89
+- name: jx-go-loops
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.2
 - name: springprojectnew
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.3


### PR DESCRIPTION
chore: Promote jx-go-loops to version 0.0.2